### PR TITLE
Correct erroneous or misleading library description

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,10 +1,10 @@
 name=DS3231_RTC
 version=1.1.0
 author=Affan Hanif, Andrew Wickert <awickert@umn.edu>, Eric Ayars, Jean-Claude Wippler, Northern Widget LLC <info@northernwidget.com>
-maintainer=Andrew Wickert <awickert@umn.edu>
+maintainer=Affan Hanif <you@youremail.com>
 sentence=Arduino library for the DS3231 real-time clock (RTC)
-paragraph=Abstracts functionality for clock reading, clock setting, and alarms for the DS3231 high-precision real-time clock. This is a splice of Ayars' (http://hacks.ayars.org/2011/04/ds3231-real-time-clock.html) and Jeelabs/Ladyada's (https://github.com/adafruit/RTClib) libraries.
+paragraph=A separate fork derived from the NorthernWidget DS3231 library. Supports clock reading, clock setting, and alarms for the DS3231 high-precision real-time clock.
 category=Timing
-url=https://github.com/NorthernWidget/DS3231
+url=https://github.com/affanhanifathtarech/DS3231
 architectures=*
 includes=DS3231.h


### PR DESCRIPTION
I am one of the volunteers helping to maintain the DS3231 library for Arduino at [https://github.com/NorthernWidget/DS3231](https://github.com/NorthernWidget/DS3231]. 

Thank you for the interest you showed in our library by forking it. We hope you will contribute to its development in future, either through building upon it in your own fork or by offering pull requests to ours.

We want to make you aware of a concern and ask you to address it soon. Your recent fork of the library was published to the Arduino Library Manager under the slightly different name, "DS3231_RTC", while keeping the descriptive information unchanged. 

As a result, the descriptions of "DS3231" and "DS3231_RTC" appear identical in the Arduino Library Manager. Our concern is that users of the Arduino IDE may face some difficulty determining which library they wish to install. 

What is worse, some of the "DS3231" library descriptive information is actually incorrect for this "DS3231_RTC" library. The incorrect "url" is potentially misleading in the following way.

* The url given in the library properties file points to NorthernWidget's repo at github.
* However, the url for the repo in the Library Registry points to this affanhanifathtarech account.
* Those two urls should be the same. It is potentially misleading for them to be different.
* A user viewing the library properties url (as "more info" in the Library Manager description) could reasonably believe they were installing library code from NorthernWidget while actually getting code from another, different place. 

It is also incorrect to list Andrew Wickert's name and e-mail as the maintainer of the "DS3231_RTC" library. 

Additionally, we believe the descriptive text should make it more clear to Arduino users that this repo is different from ours. The main reason is that the DS3231 library continues to be actively updated, while this DS3231_RTC library presents a more-or-less verbatim duplicate of an older (1.1.0) version of the DS3231 library.

Our concerns can be addressed by revising the library.properties file appropriately then publishing a new version to reflect the changes.

This PR proposes relevant revisions. Please merge it. Then do the steps listed below to update the library information in the Arduino Library Manager.

1. Edit the "maintainer" line to include the correct name and e-mail address of the person responsible for maintaining your library. The repo has incorrectly used Mr. Wickert's name and e-mail here.

2. Create a new "tag", for example, 1.1.1, to identify the repo having these changes to the library.properties file. Then create a new Release for version 1.1.1, and identify it as the current version.

Please give this matter your attention and take the necessary steps soon to resolve these concerns. All users of Arduino will benefit from better clarity regarding the differences between your repo and ours.